### PR TITLE
fixed default ballot setting

### DIFF
--- a/contracts/trail/src/ballot.cpp
+++ b/contracts/trail/src/ballot.cpp
@@ -47,9 +47,9 @@ ACTION trail::newballot(name ballot_name, name category, name publisher,
     //intitial settings
     new_settings[name("lightballot")] = false;
     new_settings[name("revotable")] = true;
-    new_settings[name("votestake")] = true;
+    new_settings[name("votestake")] = trs.settings.at("stakeable");
     new_settings[name("writein")] = false;
-    //TODO: new_settings[name("allowdgate")] = true;
+    //TODO: new_settings[name("allowdgate")] = false;
 
     //emplace new ballot
     ballots.emplace(publisher, [&](auto& col){


### PR DESCRIPTION
Fix for Issue #21 

The ballot "votestake" setting now defaults to the corresponding treasury's "stakeable" setting.