### PR TITLE
Rex Exploit Patch

### DIFF
--- a/contracts/trail/include/utility.hpp
+++ b/contracts/trail/include/utility.hpp
@@ -12,19 +12,18 @@ using namespace std;
 using namespace eosio;
 
 using user_resources = eosiosystem::user_resources;
-using user_resources_table = eosiosystem::user_resources_table;
+using del_bandwidth_table = eosiosystem::del_bandwidth_table;
 using rex_bal_table = eosiosystem::rex_balance_table;
 
 //defined in 
 asset get_staked_tlos(name owner) {
-    user_resources_table userres(name("eosio"), owner.value);
-    auto r = userres.find(owner.value);
+    del_bandwidth_table delband(name("eosio"), owner.value);
+    auto r = delband.find(owner.value);
 
     int64_t amount = 0;
 
-    if (r != userres.end()) {
-        auto res = *r;
-        amount = (res.cpu_weight.amount + res.net_weight.amount);
+    if (r != delband.end()) {
+        amount = (r->cpu_weight.amount + r->net_weight.amount);
     }
     
     return asset(amount, symbol("TLOS", 4));

--- a/tests/trail_tester.hpp
+++ b/tests/trail_tester.hpp
@@ -75,7 +75,6 @@ namespace trail {
                 create_accounts({ token_name, trail_name, rex_name, ram_name, ramfee_name, stake_name, bpay_name, vpay_name, names_name });
                 setup_token_contract();
                 setup_sys_contract();
-
                 asset ram_amount = asset::from_string("400.0000 TLOS");
                 asset liquid_amount = asset::from_string("10000.0000 TLOS");
 
@@ -176,7 +175,7 @@ namespace trail {
                                                         ("receiver", a)
                                                         ("stake_net_quantity", net )
                                                         ("stake_cpu_quantity", cpu )
-                                                        ("transfer", 0 )
+                                                        ("transfer", 1 )
                                                     )
                                             );
 
@@ -1018,8 +1017,8 @@ namespace trail {
             //======================== system getters =======================
 
             fc::variant get_user_res(name account) {
-                vector<char> data = get_row_by_account(eosio_name, account, name("userres"), account);
-                return data.empty() ? fc::variant() : sys_abi_ser.binary_to_variant("user_resources", data, abi_serializer_max_time);
+                vector<char> data = get_row_by_account(eosio_name, account, name("delband"), account);
+                return data.empty() ? fc::variant() : sys_abi_ser.binary_to_variant("delegated_bandwidth", data, abi_serializer_max_time);
             }
 
             //======================== helper actions =======================

--- a/tests/trail_tests.cpp
+++ b/tests/trail_tests.cpp
@@ -817,10 +817,14 @@ BOOST_AUTO_TEST_SUITE(trail_tests)
         
         new_treasury(eosio_name, max_supply, name("public"));
 
-        reg_voter(voter1, treasury_symbol, { });
+        delegate_bw(testa, testb, asset::from_string("1.0000 TLOS"), asset::from_string("1.0000 TLOS"), false);
 
+        reg_voter(voter1, treasury_symbol, { });
+        produce_blocks();
         //check that cpu + net quantity = total staked in trail
-        fc::variant user_resource_info = get_user_res(voter1);
+        fc::variant user_resource_info = get_user_res(testa);
+        cout << user_resource_info << endl;
+
         asset current_stake = user_resource_info["net_weight"].as<asset>() + user_resource_info["cpu_weight"].as<asset>();
         int64_t staked_weight_amount = current_stake.get_amount();
 


### PR DESCRIPTION
This PR resolves an exploit discovered in trail due to its original design. Before REX was introduced, trail used the `userres` table to calculate an accounts vote weight. Now the REX system manipulates this table directly to give cpu/net loan recipients their rented resources. Because of this change loan recipients could increase their vote weight in trail by orders of magnitude. 

This PR resolves this bug by changing the staked weight calculation function. Instead of reading from `userres`, trail will now retrieve self delegated bandwidth from the `delband` table. 